### PR TITLE
BASEURL Make Client baseUrl empty on default

### DIFF
--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -21,7 +21,7 @@ class Client
     /**
      * @var string
      */
-    private $baseUrl = 'https://suite6.emarsys.net/api/v2/';
+    private $baseUrl = 'https://api.emarsys.net/api/v2/';
     /**
      * @var string
      */

--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -21,7 +21,7 @@ class Client
     /**
      * @var string
      */
-    private $baseUrl;
+    private $baseUrl = 'https://suite6.emarsys.net/api/v2/';
     /**
      * @var string
      */
@@ -55,12 +55,12 @@ class Client
      * @param HttpClient $client HTTP client implementation
      * @param string $username The username requested by the Emarsys API
      * @param string $secret The secret requested by the Emarsys API
-     * @param string $baseUrl BaseUrl
+     * @param string $baseUrl Overrides the default baseUrl if needed
      * @param array $fieldsMap Overrides the default fields mapping if needed
      * @param array $choicesMap Overrides the default choices mapping if needed
      */
     public function __construct(
-        HttpClient $client, $username, $secret, $baseUrl, $fieldsMap = array(), $choicesMap = array()
+        HttpClient $client, $username, $secret, $baseUrl = null, $fieldsMap = array(), $choicesMap = array()
     )
     {
 	    $this->client = $client;

--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -21,7 +21,7 @@ class Client
     /**
      * @var string
      */
-    private $baseUrl = 'https://suite6.emarsys.net/api/v2/';
+    private $baseUrl;
     /**
      * @var string
      */
@@ -55,12 +55,12 @@ class Client
      * @param HttpClient $client HTTP client implementation
      * @param string $username The username requested by the Emarsys API
      * @param string $secret The secret requested by the Emarsys API
-     * @param string $baseUrl Overrides the default baseUrl if needed
+     * @param string $baseUrl BaseUrl
      * @param array $fieldsMap Overrides the default fields mapping if needed
      * @param array $choicesMap Overrides the default choices mapping if needed
      */
     public function __construct(
-        HttpClient $client, $username, $secret, $baseUrl = null, $fieldsMap = array(), $choicesMap = array()
+        HttpClient $client, $username, $secret, $baseUrl, $fieldsMap = array(), $choicesMap = array()
     )
     {
 	    $this->client = $client;


### PR DESCRIPTION
Base url parameter should not have default value as any new client has
his own `suite uri` like http://suite15.emarsys.net and must use only
that uri. Base uri is part of credentials and it is personal. No common
value for all!

You made it with default value and there is no any warning or error when
first trying to use this package. It's easy to forget to pass right base
uri. It leads to time wasting when trying to understand what's wrong
when API doesn't work but username and secret are correct.