### PR TITLE
Fixes unit tests

### DIFF
--- a/tests/Unit/Suites/CurlClientTest.php
+++ b/tests/Unit/Suites/CurlClientTest.php
@@ -29,6 +29,6 @@ class CurlClientTest extends \PHPUnit_Framework_TestCase
 	{
 		$result = $this->client->send('GET', 'http://google.com', array(), array('foo' => 'bar'));
 
-		$this->assertContains('<HTML', $result);
+		$this->assertContains('<html', $result);
 	}
 }


### PR DESCRIPTION
A change in Google markup has caused one of the tests to fail, simple fix for the issue.