### PR TITLE
Added some missing functions related to Contacts and Contact Lists

### DIFF
--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -395,6 +395,18 @@ class Client
     }
 
     /**
+     * Get a list of contact IDs that are in a contact list
+     *
+     * @param string $listId
+     * @param array $data
+     * @return Response
+     */
+    public function getContactsFromContactList($listId, array $data)
+    {
+        return $this->send(HttpClient::GET, sprintf('contactlist/%s/contacts', $listId), $data);
+    }
+
+    /**
      * Returns a list of emails.
      *
      * @param int|null $status

--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -360,6 +360,17 @@ class Client
     }
 
     /**
+     * Deletes a contact list which can be used as recipient source for the email.
+     *
+     * @param string $listId
+     * @return Response
+     */
+    public function deleteContactList($listId)
+    {
+        return $this->send(HttpClient::POST, sprintf('contactlist/%s/deletelist', $listId));
+    }
+
+    /**
      * Creates a contact list which can be used as recipient source for the email.
      *
      * @param string $listId

--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -264,6 +264,17 @@ class Client
     }
 
     /**
+     * Deletes a single contact/recipient, identified by an external ID.
+     *
+     * @param array $data
+     * @return Response
+     */
+    public function deleteContact(array $data)
+    {
+        return $this->send(HttpClient::POST, 'contact/delete', $data);
+    }
+
+    /**
      * Returns the internal ID of a contact specified by its external ID.
      *
      * @param string $fieldId


### PR DESCRIPTION
Why?
* There existed a method to create a contact list, but no method to delete one.
* There also existed a method to get all the contact lists, but no method to get the contacts inside of a contact list.

This change addresses the need by:
* Adding a method to `Client` that makes use of the Emarsys `deletelist` call to delete a contact list
* Adding a method to `Client` that makes use of the Emarsys `contactlist/<list_id>/contacts` call to get all contacts in a contact list