### PR TITLE
Fix issues for Relational Data Service endpoints

### DIFF
--- a/src/Snowcap/Emarsys/HttpClient.php
+++ b/src/Snowcap/Emarsys/HttpClient.php
@@ -4,17 +4,18 @@ namespace Snowcap\Emarsys;
 
 interface HttpClient
 {
-	const GET = 'GET';
-	const POST = 'POST';
-	const PUT = 'PUT';
-	const DELETE = 'DELETE';
+    const GET = 'GET';
+    const POST = 'POST';
+    const PUT = 'PUT';
+    const DELETE = 'DELETE';
+    const PATCH = 'PATCH';
 
-	/**
-	 * @param string $method
-	 * @param string $uri
-	 * @param string[] $headers
-	 * @param array $body
-	 * @return string
-	 */
-	public function send($method, $uri, array $headers, array $body);
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param string[] $headers
+     * @param array $body
+     * @return string
+     */
+    public function send($method, $uri, array $headers, array $body);
 }

--- a/src/Snowcap/Emarsys/Response.php
+++ b/src/Snowcap/Emarsys/Response.php
@@ -32,15 +32,15 @@ class Response
      * @param array $result
      * @throws ClientException
      */
-    function __construct(array $result = array())
+    public function __construct(array $result = array())
     {
-        if (!isset($result['replyCode']) || !isset($result['replyText']) || !isset($result['data'])) {
+        if (!isset($result['replyCode']) || !isset($result['replyText'])) {
             throw new ClientException('Invalid result structure');
         }
 
         $this->replyCode = $result['replyCode'];
         $this->replyText = $result['replyText'];
-        $this->data = $result['data'];
+        $this->data = (isset($result['data'])) ? $result['data'] : [];
     }
 
     /**

--- a/src/Snowcap/Emarsys/Response.php
+++ b/src/Snowcap/Emarsys/Response.php
@@ -40,7 +40,7 @@ class Response
 
         $this->replyCode = $result['replyCode'];
         $this->replyText = $result['replyText'];
-        $this->data = (isset($result['data'])) ? $result['data'] : [];
+        $this->data = isset($result['data']) ? $result['data'] : [];
     }
 
     /**


### PR DESCRIPTION
1. "Invalid result structure" Exception is throwing for Relational Data Service Responses.
Exception is throwing, because RDS response structure is
{
   "replyCode": 0,
   "replyText": ""
}

2. RDS Updating endpoint needs PATCH http method.