### PR TITLE
GET Endpoint /contactlist doesn't accept any data

### DIFF
--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -357,12 +357,11 @@ class Client
     /**
      * Returns a list of contact lists which can be used as recipient source for the email.
      *
-     * @param array $data
      * @return Response
      */
-    public function getContactList(array $data)
+    public function getContactList()
     {
-        return $this->send(HttpClient::GET, 'contactlist', $data);
+        return $this->send(HttpClient::GET, 'contactlist');
     }
 
     /**


### PR DESCRIPTION
As stated in the official documentation, the `GET` endpoint `/contactlist` is not filterable as you would think by the current implementation.

If you provide anything but an empty array, you'll receive the following, misleading error:

```php
object(Snowcap\Emarsys\Response)#4 (3) { ["replyCode":protected]=> int(10001) ["replyText":protected]=> string(21) "Invalid filter: limit" ["data":protected]=> string(0) "" }
```

I propose to remove the need of specifying an array completely.