### PR TITLE
 Throw a ServerException instead of Fatal when the server response is invalid

### DIFF
--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -820,6 +820,10 @@ class Client
             }
         }
 
+        if (is_array($responseArray) === false) {
+            throw new ServerException("JSON response is not an array:\n" . $responseArray);
+        }
+
         return new Response($responseArray);
     }
 


### PR DESCRIPTION
We should not trust Emarsys servers, this case happens this morning.