### PR TITLE
fix: Create default for uri parameter in send method

### DIFF
--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -893,8 +893,12 @@ class Client
      * @throws ClientException
      * @throws ServerException
      */
-    protected function send($method = 'GET', $uri, array $body = array())
+    protected function send($method = 'GET', $uri = '', array $body = array())
     {
+        if (empty($uri)) {
+            throw new ServerException('The uri must not be empty.');
+        }
+
         $headers = array('Content-Type: application/json', 'X-WSSE: ' . $this->getAuthenticationSignature());
         $uri = $this->baseUrl . $uri;
 


### PR DESCRIPTION
A requiered parameter must not come after an optional parameter, since PHP 8.1.
To work around this error, the parameter becomes an optional and is checked first.